### PR TITLE
crawl for geom_alt prop updates

### DIFF
--- a/data/856/722/75/85672275.geojson
+++ b/data/856/722/75/85672275.geojson
@@ -501,6 +501,9 @@
         "wd:id":"Q36004"
     },
     "wof:country":"XZ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f00b32da49eae6124ca7388138b114da",
     "wof:hierarchy":[
         {
@@ -513,7 +516,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566657686,
+    "wof:lastmodified":1582331740,
     "wof:name":"Cocos (Keeling) Islands",
     "wof:parent_id":-1,
     "wof:placetype":"region",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. 

This will not require PIP work to update hierarchies.