### PR TITLE
xz concordances, placetype local, and more

### DIFF
--- a/data/856/722/75/85672275.geojson
+++ b/data/856/722/75/85672275.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.001139,
-    "geom:area_square_m":13770762.505368,
+    "geom:area_square_m":13770755.243956,
     "geom:bbox":"96.816941,-12.208726,96.929489,-11.81462",
     "geom:latitude":-12.134591,
     "geom:longitude":96.862241,
@@ -532,15 +532,17 @@
         "fips:code":"CK",
         "gp:id":23424784,
         "hasc:id":"CC.CC",
+        "iso:code":"CC-CC",
         "iso:id":"CC-CC",
         "qs_pg:id":1087766,
         "wd:id":"Q36004"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"XZ",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"8dd6d40b5d7c97a937d983cdbc21c6f5",
+    "wof:geomhash":"cbcf803ffc0ad8cf21b7b31e74b136ca",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -552,7 +554,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1690924052,
+    "wof:lastmodified":1695884356,
     "wof:name":"Cocos (Keeling) Islands",
     "wof:parent_id":-1,
     "wof:placetype":"region",

--- a/data/856/813/31/85681331.geojson
+++ b/data/856/813/31/85681331.geojson
@@ -168,7 +168,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1694493257,
+    "wof:lastmodified":1695884852,
     "wof:name":"Spratly Islands",
     "wof:parent_id":85632177,
     "wof:placetype":"region",

--- a/data/856/813/57/85681357.geojson
+++ b/data/856/813/57/85681357.geojson
@@ -263,7 +263,7 @@
         }
     ],
     "wof:id":85681357,
-    "wof:lastmodified":1694493125,
+    "wof:lastmodified":1695884281,
     "wof:name":"Scarborough Reef",
     "wof:parent_id":85632479,
     "wof:placetype":"region",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.